### PR TITLE
Add native engine fallback guardrails

### DIFF
--- a/doxa/query/postgres.py
+++ b/doxa/query/postgres.py
@@ -24,6 +24,7 @@ Usage::
 from __future__ import annotations
 
 import hashlib
+import os
 from typing import TYPE_CHECKING
 
 from doxa.core.branch import Branch
@@ -59,6 +60,10 @@ from doxa.query.evaluator import (
 )
 
 
+class PostgresNativeFallbackError(RuntimeError):
+    """Raised when strict native SQL mode forbids Python evaluator fallback."""
+
+
 class PostgresQueryEngine(QueryEngine):
     """Epistemic query engine backed by a PostgreSQL repository.
 
@@ -72,6 +77,14 @@ class PostgresQueryEngine(QueryEngine):
     repo:
         A :class:`~doxa.persistence.postgres.PostgresBranchRepository`
         used to fetch belief records with server-side filtering.
+    native_sql_enabled:
+        Enable the native SQL evaluator for the supported fragment. When it is
+        disabled or unsupported, the engine normally falls back to the shared
+        Python evaluator.
+    native_sql_strict:
+        Forbid fallback when native SQL is enabled. This is intended for tests
+        and native acceptance checks so unsupported constructs are visible
+        instead of being silently handled by the Python evaluator.
     """
 
     def __init__(
@@ -79,20 +92,33 @@ class PostgresQueryEngine(QueryEngine):
         repo: "PostgresBranchRepository",
         *,
         native_sql_enabled: bool | None = None,
+        native_sql_strict: bool | None = None,
         auto_sync_on_evaluate: bool = True,
     ) -> None:
         self._repo = repo
         self._synced_branch_signatures: dict[str, str] = {}
         self._native_sql_enabled = native_sql_enabled
+        self._native_sql_strict = native_sql_strict
         self._auto_sync_on_evaluate = auto_sync_on_evaluate
         self.last_native_fallback_reason: str | None = None
 
     def _use_native_sql(self) -> bool:
         if self._native_sql_enabled is not None:
             return self._native_sql_enabled
-        import os
-
         return os.environ.get("DOXA_POSTGRES_NATIVE_SQL") == "1"
+
+    def _strict_native_sql(self) -> bool:
+        if self._native_sql_strict is not None:
+            return self._native_sql_strict
+        return os.environ.get("DOXA_POSTGRES_NATIVE_SQL_STRICT") == "1"
+
+    def _handle_native_fallback(self, reason: str) -> None:
+        self.last_native_fallback_reason = reason
+        if self._strict_native_sql():
+            raise PostgresNativeFallbackError(
+                "Postgres native SQL fallback is disabled in strict mode: "
+                f"{reason}"
+            )
 
     @property
     def info(self) -> EngineInfo:
@@ -159,14 +185,17 @@ class PostgresQueryEngine(QueryEngine):
         if self._use_native_sql():
             supported, reason = probe_native_support(branch, query)
             if not supported:
-                self.last_native_fallback_reason = reason
+                self._handle_native_fallback(reason or "native SQL support probe failed")
             else:
-                self.last_native_fallback_reason = None
-            native_result = try_evaluate_native(
-                self._repo.get_connection(), branch, query
-            )
-            if native_result is not None:
-                return native_result
+                native_result = try_evaluate_native(
+                    self._repo.get_connection(), branch, query
+                )
+                if native_result is not None:
+                    self.last_native_fallback_reason = None
+                    return native_result
+                self._handle_native_fallback(
+                    "native SQL evaluator returned no result for a supported query"
+                )
 
         # ── Fast path: load only visible records from PostgreSQL ──────
         records = self._repo.get_visible_belief_records(

--- a/tests/query/test_native_guardrails.py
+++ b/tests/query/test_native_guardrails.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from doxa.core.branch import Branch
+from doxa.core.query import Query
+from doxa.query.postgres import PostgresNativeFallbackError, PostgresQueryEngine
+
+
+class _DummyRepo:
+    def __init__(self) -> None:
+        self.connection_requested = False
+        self.visible_records_requested = False
+
+    def save(self, branch: Branch) -> None:
+        raise AssertionError("test should disable auto-sync")
+
+    def get_connection(self):
+        self.connection_requested = True
+        raise AssertionError("unsupported native SQL must not request a DB connection")
+
+    def get_visible_belief_records(self, *args, **kwargs):
+        self.visible_records_requested = True
+        return []
+
+
+def test_postgres_native_sql_strict_rejects_constraint_fallback(monkeypatch):
+    branch = Branch.from_doxa(
+        """
+        p(a).
+        q(a).
+        !:- p(X), q(X) @{b:0.7}.
+        """
+    )
+    query = Query.from_doxa('?- p(a), q(a) @{explain:"false"}')
+    repo = _DummyRepo()
+    engine = PostgresQueryEngine(
+        repo,
+        native_sql_enabled=True,
+        native_sql_strict=True,
+        auto_sync_on_evaluate=False,
+    )
+
+    def _forbid_python_fallback(*args, **kwargs):
+        raise AssertionError("Python evaluator fallback was used")
+
+    monkeypatch.setattr(
+        "doxa.query.postgres.evaluate_with_records",
+        _forbid_python_fallback,
+    )
+
+    with pytest.raises(PostgresNativeFallbackError, match="constraints"):
+        engine.evaluate(branch, query)
+
+    assert engine.last_native_fallback_reason == "constraints are not supported by native SQL"
+    assert repo.connection_requested is False
+    assert repo.visible_records_requested is False
+
+
+def test_postgres_native_sql_records_non_strict_fallback_reason():
+    branch = Branch.from_doxa(
+        """
+        p(a).
+        q(a).
+        !:- p(X), q(X) @{b:0.7}.
+        """
+    )
+    query = Query.from_doxa('?- p(a), q(a) @{explain:"false"}')
+    repo = _DummyRepo()
+    engine = PostgresQueryEngine(
+        repo,
+        native_sql_enabled=True,
+        native_sql_strict=False,
+        auto_sync_on_evaluate=False,
+    )
+
+    result = engine.evaluate(branch, query)
+
+    assert engine.last_native_fallback_reason == "constraints are not supported by native SQL"
+    assert repo.connection_requested is False
+    assert repo.visible_records_requested is True
+    assert result.answers


### PR DESCRIPTION
## Summary

- add `PostgresNativeFallbackError` and a `native_sql_strict` flag to `PostgresQueryEngine`
- support `DOXA_POSTGRES_NATIVE_SQL_STRICT=1` so native SQL tests can fail fast instead of silently falling back to the Python evaluator
- keep non-strict behavior backward-compatible while recording `last_native_fallback_reason`
- add guardrail tests covering constraint fallback behavior without requiring a real Postgres connection

## Why

The native SQL evaluator intentionally supports only a narrower fragment. Before this change, unsupported cases such as constraints could be handled by the shared Python evaluator and still pass tests, which hides missing native functionality.

## Notes

This PR fixes the immediate silent-fallback issue. It does not implement native Rust constraint semantics or native EDB branch replacement; those should remain separate follow-up tasks because they require Rust-side storage/evaluator changes.

## Test status

I could not run the test suite locally from this environment because direct GitHub/DNS access for cloning was unavailable, so this PR is based on static review plus connector-level file edits.